### PR TITLE
VersionUp Logic -- NoDB logic

### DIFF
--- a/woody/ui/project.py
+++ b/woody/ui/project.py
@@ -10,6 +10,7 @@ from ..lib.mongodb import create_blend_db
 from ..plugins.blender.blender_instance import BlenderInstance
 
 import customtkinter
+import re
 import threading
 import time
 
@@ -55,6 +56,15 @@ class ProjectFrame:
 
 
     def _create_blend_file(self):
+        blend_name = self.blendNameEntry.get().strip()
+        # Validate blend name - prevent _latest and _v* patterns
+        if self._is_invalid_blend_name(blend_name):
+            print(
+                "Invalid Name", 
+                "Blend name cannot contain '_latest' or version suffixes like '_v1', '_v2', etc.\n"
+                "These suffixes are reserved for the versioning system."
+            )
+            return
         group_type = "assets" if self.groupTypeComboBox.get() == "Assets Group" else "shots"
         
         # Try to create the database entry first
@@ -74,6 +84,13 @@ class ProjectFrame:
         else:
             print("Failed to create database entry - blend file not created")
        
+    def _is_invalid_blend_name(self, name: str) -> bool:
+        """Check if blend name contains reserved suffixes"""
+        if "_latest" in name:
+            return True
+        if re.search(r"_v\d+", name):
+            return True
+        return False
 
     def _open_blend_file(self):
         group_type = "assets" if self.groupTypeComboBox.get() == "Assets Group" else "shots"

--- a/woody_blender_addon/__init__.py
+++ b/woody_blender_addon/__init__.py
@@ -9,13 +9,15 @@ bl_info = {
 }
 
 import bpy 
-from .panel import *
+from .panel import VIEW3D_PT_context
+from .operators.version_up import WOODY_OT_version_up
 
 
 # =============== Registration ===============
 
 classes = [
-    VIEW3D_PT_context
+    VIEW3D_PT_context,
+    WOODY_OT_version_up
 ]
 
 

--- a/woody_blender_addon/operators/__init__.py
+++ b/woody_blender_addon/operators/__init__.py
@@ -1,0 +1,5 @@
+from .version_up import WOODY_OT_version_up
+
+__all__ = [
+    'WOODY_OT_version_up'
+]

--- a/woody_blender_addon/operators/version_up.py
+++ b/woody_blender_addon/operators/version_up.py
@@ -1,0 +1,76 @@
+import bpy
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+class WOODY_OT_version_up(bpy.types.Operator):
+    bl_idname = "woody.version_up"
+    bl_label = "Version Up"
+    bl_description = "Save current scene and create a new version"
+    
+    def execute(self, context):
+        try:
+            # Check if scene has been saved
+            if not bpy.data.filepath:
+                self.report({'ERROR'}, "Scene has not been saved before. Save it first.")
+                return {'CANCELLED'}
+            
+            # Save current scene first
+            bpy.ops.wm.save_mainfile()
+            
+            # Get current file info
+            current_path = Path(bpy.data.filepath)
+            directory = current_path.parent
+            extension = current_path.suffix
+            filename = current_path.stem
+            
+            # Remove _latest suffix if it exists
+            base_filename = filename.replace("_latest", "")
+            
+            print(f"Processing file: {base_filename}")
+            
+            # Find existing versions
+            version_pattern = re.compile(rf"{re.escape(base_filename)}_v(\d+){re.escape(extension)}$")
+            existing_versions = []
+            
+            for file in directory.iterdir():
+                if file.is_file():
+                    match = version_pattern.match(file.name)
+                    if match:
+                        existing_versions.append(int(match.group(1)))
+            
+            # Calculate next version
+            next_version = max(existing_versions, default=0) + 1
+            new_filename = f"{base_filename}_v{next_version}{extension}"
+            new_file_path = directory / new_filename
+            
+            # Copy current file to new version
+            shutil.copy2(current_path, new_file_path)
+
+            # Create the new _latest filename
+            new_latest_filename = f"{base_filename}_latest{extension}"
+            new_latest_path = directory / new_latest_filename
+            
+            # Save current scene as _latest (this will rename the current file)
+            bpy.ops.wm.save_as_mainfile(filepath=str(new_latest_path))
+
+            # Remove the original file if it's different from the new _latest file
+            if current_path != new_latest_path and current_path.exists():
+                os.remove(current_path)
+                # Remove Blender's automatic backup file (.blend1)
+                backup_file = current_path.with_suffix(current_path.suffix + '1')
+                if backup_file.exists():
+                    os.remove(backup_file)
+            
+            print(f"Created version: {new_file_path}")
+            print(f"Working file: {new_latest_path}")
+            self.report({'INFO'}, f"Version {next_version} created successfully")
+            
+            return {'FINISHED'}
+            
+        except Exception as e:
+            self.report({'ERROR'}, f"Version up failed: {str(e)}")
+            return {'CANCELLED'}
+        

--- a/woody_blender_addon/panel.py
+++ b/woody_blender_addon/panel.py
@@ -5,13 +5,16 @@ class VIEW3D_PT_context(bpy.types.Panel):
     bl_idname = "VIEW3D_PT_woody_context"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
-    bl_label = "Hello"
+    bl_label = "Woody Pipeline"
     bl_category = "Woody"
 
     def draw(self, context):
         layout = self.layout
-
-            
+        
         rootBox = layout.box()
-        rootBox.label(text=f"777", icon="OUTLINER")
+        rootBox.label(text="Woody Tools", icon="OUTLINER")
         rootBox.scale_y = 0.75
+        
+        # Add Version Up button
+        row = rootBox.row()
+        row.operator("woody.version_up", text="Version Up", icon="FILE_REFRESH")


### PR DESCRIPTION
Allows version up in blender addon. Duplicates current blend file names the copy "name"_v(highest number+ 1) and renames the current file to "name"_latest.

Also disallows the naming of a blend file to include _latest or _v*